### PR TITLE
code 제안

### DIFF
--- a/Main.py
+++ b/Main.py
@@ -1,11 +1,5 @@
 from parameter import para
 
-ReactorPower = para.ReatorPower # T
-BoronConcentration = para.BoronConcentration # T
-Burnup = para.Burnup # T
-InoperableRodNumber = para.InoperableRodNumber # T
-InoperableRodName = para.InpoerableRodName # T
-
 def ShutdownMarginCalculation(ReactorPower, Burnup, InoperableRodNumber, InoperableRodName):
     ##################################################
     # BOL일때, 현출력 -> 0% 하기위한 출력 결손량을 계산하자.
@@ -134,12 +128,20 @@ def ShutdownMarginCalculation(ReactorPower, Burnup, InoperableRodNumber, Inopera
 
     #print(para.ShutdownMarginValue)
 
+# 2. 의 코드 제안
     if ShudownMargin >= para.ShutdownMarginValue :
-        A=print('만족')
+#         A=print('만족')
+        return ShudownMargin, print('만족')
     else :
-        A=print('불만족')
+#         A=print('불만족')
+        return ShudownMargin, print('불만족')
+#     return ShudownMargin, A
 
-    return ShudownMargin, A
+# 3. 의 코드 제안, 해당 변수가 사용되고 있지 않음.
+# BoronConcentration = para.BoronConcentration # T
 
 
-ShutdownMarginCalculation(ReactorPower=ReactorPower, Burnup=Burnup, InoperableRodNumber=InoperableRodNumber, InoperableRodName=InoperableRodName)
+ShutdownMarginCalculation(ReactorPower=para.ReatorPower
+                          , Burnup=para.Burnup
+                          , InoperableRodNumber=para.InoperableRodNumber
+                          , InoperableRodName=para.InpoerableRodName)


### PR DESCRIPTION
1. A, B, C 로 변수 선언시 코드가 길어지면 혼동할 가능성과 타 라이브러리와 충돌 할 수 있음. ( 예를들어 A라고 사용하면 글로벌 변수인지 전역변수 인지 혼동되며, 동일한 변수명에 값을 여러개 지정해버리는 경우가 생김)
2. if then에서 return을 쓰면 코드의 가독성을 높혀줄 수 있음.
3. 불필요한 글로벌 및 전역변수 선언 자제